### PR TITLE
Set library version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ add_library(keyfinder
   src/constants.cpp
 )
 
+set_target_properties(keyfinder PROPERTIES
+	SOVERSION ${PROJECT_VERSION_MAJOR}
+	VERSION ${PROJECT_VERSION})
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(FFTW3 REQUIRED)
 target_link_libraries(keyfinder PUBLIC FFTW3::fftw3)


### PR DESCRIPTION
This allows distributions to split out development files properly to a -dev package. The resulting library now gets named `libkeyfinder.so.2.2.4` with symlinks to `libkeyfinder.so.2` and `libkeyfinder.so`. This also allows packagers to more easily track updates that requires rebuilding or updates of mixxx