### PR TITLE
Disable test builds on Windows and use macOS 11 in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,6 +21,7 @@ jobs:
             os: windows-2019
             install_dir: C:\libKeyFinder
             cmake_extras: >-
+              -DBUILD_TESTING=OFF
               -DVCPKG_TARGET_TRIPLET=x64-windows-static
               -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake
             cmake_config: --config RelWithDebInfo

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,8 +13,8 @@ jobs:
             os: ubuntu-20.04
             install_dir: ~/libKeyFinder
             cmake_extras: -DCMAKE_BUILD_TYPE=RelWithDebInfo
-          - name: macOS 10.15
-            os: macos-10.15
+          - name: macOS 11
+            os: macos-11
             install_dir: ~/libKeyFinder
             cmake_extras: -DCMAKE_BUILD_TYPE=RelWithDebInfo
           - name: Windows 2019


### PR DESCRIPTION
We don't run the tests there anyway currently, so hopefully this should fix Windows CI (for now). This is effectively the same fix as https://github.com/microsoft/vcpkg/pull/30454.