### PR TITLE
Bump versions of actions and runners in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Ubuntu 20.04
-            os: ubuntu-20.04
+          - name: Ubuntu 22.04
+            os: ubuntu-22.04
             install_dir: ~/libKeyFinder
             cmake_extras: -DCMAKE_BUILD_TYPE=RelWithDebInfo
           - name: macOS 11

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out Git repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: "[Ubuntu] Install dependencies"
       if: startsWith(matrix.os, 'ubuntu')
       run: |
@@ -41,7 +41,7 @@ jobs:
       if: startsWith(matrix.os, 'macos')
       run: brew install fftw catch2
     - name: "[Windows] Set up vcpkg cache"
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       if: runner.os == 'Windows'
       with:
         path: C:\Users\runneradmin\AppData\Local\vcpkg\archives
@@ -83,7 +83,7 @@ jobs:
       env:
         CMAKE_PREFIX_PATH: ${{ matrix.install_dir }}
     - name: Upload Build Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }} libKeyFinder build
         path: ${{ matrix.install_dir }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,8 +13,8 @@ jobs:
             os: ubuntu-22.04
             install_dir: ~/libKeyFinder
             cmake_extras: -DCMAKE_BUILD_TYPE=RelWithDebInfo
-          - name: macOS 11
-            os: macos-11
+          - name: macOS 12
+            os: macos-12
             install_dir: ~/libKeyFinder
             cmake_extras: -DCMAKE_BUILD_TYPE=RelWithDebInfo
           - name: Windows 2019


### PR DESCRIPTION
Ubuntu 20.04 and macOS 11 runners have been deprecated/removed. Since we no longer use them for the main repo either, we should update them here. While we are at it, this also bumps the actions in the workflow.